### PR TITLE
Add settings for date & time format

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,22 +3,64 @@ A dark tmux color scheme for terminal that support [True Color](https://en.wikip
 
 ## Why?
 
-I wanted both vim and tmux to share the same color scheme.  
-I tried [tmuxline.vim](https://github.com/edkolev/tmuxline.vim) but it didn't render the colors correctly.  
+I wanted both vim and tmux to share the same color scheme.
+I tried [tmuxline.vim](https://github.com/edkolev/tmuxline.vim) but it didn't render the colors correctly.
 Furthermore, with `tmuxline.vim`, you can't control the widgets on right status bar, which is a key feature IMO.
 
-A picture of my terminal with *@onedark_widgets* set to "*#{package_updates} #{free_mem}*" These widgets are available in [tmux-status-variables](https://github.com/odedlaz/tmux-status-variables).  
-![tmux-onedark-theme Preview](https://raw.githubusercontent.com/odedlaz/tmux-onedark-theme/master/preview-terminal.png)  
+A picture of my terminal with *@onedark_widgets* set to "*#{package_updates} #{free_mem}*".  
+These widgets are available in [tmux-status-variables](https://github.com/odedlaz/tmux-status-variables).
+![tmux-onedark-theme Preview](https://raw.githubusercontent.com/odedlaz/tmux-onedark-theme/master/preview-terminal.png)
 
 ### Set Options
 
 **!** Set the following options in your `.tmux.conf`
 
-You can control the widgets on `right-status` by setting `@onedark_widgets`, for example:
+####widgets
+
+Widgets can be controlled by setting `@onedark_widgets`, for example:
 
 ```
 set -g @onedark_widgets "#(date +%s)"
 ```
+
+Once set, these widgets will show on the right.
+
+**default**: empty string.
+
+####Time format
+
+Time format can be controlled by setting "@onedark_time_format", for example:
+
+```
+set -g @onedark_time_format "%I:%M %p"
+```
+
+`%I` - The hour as a decimal number using a 12-hour clock  
+`%M` - The minute as a decimal number  
+`%p` -  Either "AM" or "PM" according to the given time value.
+
+**default**: `%R` - The time in 24-hour notation (%H:%M).
+
+These modifiers were taken from from strftime
+[manpage](http://man7.org/linux/man-pages/man3/strftime.3.html).
+
+####Time format
+
+Date format can be controlled by setting "@onedark_date_format", for example:
+
+```
+set -g @onedark_date_format "%D"
+```
+
+`%D` - Equivalent to %m/%d/%y.   
+`%m` - The month as a decimal number.  
+`%d` - The day of the month as a decimal number  
+`%y` - The year as a decimal number without the century.  
+
+**default**: `%d/%m/%Y` - The date in non-American format.
+
+These modifiers were taken from from strftime
+[manpage](http://man7.org/linux/man-pages/man3/strftime.3.html).
 
 ### Installation with [Tmux Plugin Manager](https://github.com/tmux-plugins/tpm) (recommended)
 
@@ -46,18 +88,18 @@ Reload TMUX environment (type this in terminal)
 
 ### Symbols are missing
 
-The theme requires Powerline symbols exist on your system. Follow [these instructions](https://github.com/powerline/fonts) to install them.
+   The theme requires Powerline symbols exist on your system. Follow [these instructions](https://github.com/powerline/fonts) to install them.
 
 ### Widgets not working
 
-Make sure that you put the `set -g @plugin 'odedlaz/tmux-onedark-theme'` before other scripts that alter the status line, or they won't be able to pickup the plugin's changes.
+   Make sure that you put the `set -g @plugin 'odedlaz/tmux-onedark-theme'` before other scripts that alter the status line, or they won't be able to pickup the plugin's changes.
 
 ### True Color
 
-   tmux version <= 2.3, don't support true color in the status line.  
-   [Support has been added](https://github.com/tmux/tmux/issues/490), and will probably ship in the next release.  
+   tmux version <= 2.3, don't support true color in the status line.
+   [Support has been added](https://github.com/tmux/tmux/issues/490), and will probably ship in the next release.
    You can compile tmux and enjoy True Color right away!
-   
+
    Make sure TrueColor is enabled and working. follow [these instructions](https://sunaku.github.io/tmux-24bit-color.html#usage) to do so.
 
 ### License

--- a/tmux-onedark-theme.tmux
+++ b/tmux-onedark-theme.tmux
@@ -8,8 +8,16 @@ onedark_green="#98c379"
 onedark_visual_grey="#3e4452"
 onedark_comment_grey="#5c6370"
 
-get_widgets() {
-   echo "$(tmux show-option -gqv "@onedark_widgets")"
+get() {
+   local option=$1
+   local default_value=$2
+   local option_value="$(tmux show-option -gqv "$option")"
+
+   if [ -z "$option_value" ]; then
+      echo "$default_value"
+   else
+      echo "$option_value"
+   fi
 }
 
 set() {
@@ -67,7 +75,11 @@ set "@prefix_highlight_bg" "$onedark_green"
 set "@prefix_highlight_copy_mode_attr" "fg=$onedark_black,bg=$onedark_green"
 set "@prefix_highlight_output_prefix" "  "
 
-set "status-right" "#[fg=$onedark_white,bg=$onedark_black,nounderscore,noitalics]%H:%M  %d/%m/%y #[fg=$onedark_visual_grey,bg=$onedark_black]#[fg=$onedark_visual_grey,bg=$onedark_visual_grey]#[fg=$onedark_white, bg=$onedark_visual_grey]$(get_widgets) #[fg=$onedark_green,bg=$onedark_visual_grey,nobold,nounderscore,noitalics]#[fg=$onedark_black,bg=$onedark_green,bold] #h #[fg=$onedark_yellow, bg=$onedark_green]#[fg=$onedark_red,bg=$onedark_yellow]"
+status_widgets=$(get "@onedark_widgets")
+time_format=$(get "@onedark_time_format" "%R")
+date_format=$(get "@onedark_date_format" "%d/%m/%Y")
+
+set "status-right" "#[fg=$onedark_white,bg=$onedark_black,nounderscore,noitalics]${time_format}  ${date_format} #[fg=$onedark_visual_grey,bg=$onedark_black]#[fg=$onedark_visual_grey,bg=$onedark_visual_grey]#[fg=$onedark_white, bg=$onedark_visual_grey]${status_widgets} #[fg=$onedark_green,bg=$onedark_visual_grey,nobold,nounderscore,noitalics]#[fg=$onedark_black,bg=$onedark_green,bold] #h #[fg=$onedark_yellow, bg=$onedark_green]#[fg=$onedark_red,bg=$onedark_yellow]"
 set "status-left" "#[fg=$onedark_visual_grey,bg=$onedark_green,bold] #S #{prefix_highlight}#[fg=$onedark_green,bg=$onedark_black,nobold,nounderscore,noitalics]"
 
 set "window-status-format" "#[fg=$onedark_black,bg=$onedark_black,nobold,nounderscore,noitalics]#[fg=$onedark_white,bg=$onedark_black] #I  #W #[fg=$onedark_black,bg=$onedark_black,nobold,nounderscore,noitalics]"


### PR DESCRIPTION
Add ability to set time and format via `@onedark_time_format` and `@onedark_date_format`.
tmux uses [strftime](man7.org/linux/man-pages/man3/strftime.3.html) under the hood to format strings.

Any value that *strftime* accepts, tmux accepts as well.