### PR TITLE
fix border background colors

### DIFF
--- a/tmux-onedark-theme.tmux
+++ b/tmux-onedark-theme.tmux
@@ -62,7 +62,9 @@ set "window-style" "fg=$onedark_comment_grey,bg=$onedark_black"
 set "window-active-style" "fg=$onedark_white,bg=$onedark_black"
 
 set "pane-border-fg" "$onedark_white"
-set "pane-active-border-fg" "$onedark_white"
+set "pane-border-bg" "$onedark_black"
+set "pane-active-border-fg" "$onedark_green"
+set "pane-active-border-bg" "$onedark_black"
 
 set "display-panes-active-colour" "$onedark_yellow"
 set "display-panes-colour" "$onedark_blue"


### PR DESCRIPTION
- The border-bg should be `onedark_black` instead of `default`
- The *active* border-fg should be `onedark_green` instead of `onedark_white`

Before the fix:
<img width="743" alt="screen shot 2018-07-03 at 3 00 14 pm" src="https://user-images.githubusercontent.com/28383668/42246877-25f4b6ca-7ed3-11e8-96e1-fae1a84cf886.png">

After the fix:
<img width="767" alt="screen shot 2018-07-03 at 3 06 22 pm" src="https://user-images.githubusercontent.com/28383668/42246881-2a2decfc-7ed3-11e8-9f94-21f5cdfe367e.png">
