### PR TITLE
Support terminal transparency by not setting window backgrounds

### DIFF
--- a/tmux-onedark-theme.tmux
+++ b/tmux-onedark-theme.tmux
@@ -58,8 +58,8 @@ setw "window-status-activity-attr" "none"
 
 setw "window-status-separator" ""
 
-set "window-style" "fg=$onedark_comment_grey,bg=$onedark_black"
-set "window-active-style" "fg=$onedark_white,bg=$onedark_black"
+set "window-style" "fg=$onedark_comment_grey"
+set "window-active-style" "fg=$onedark_white"
 
 set "pane-border-fg" "$onedark_white"
 set "pane-active-border-fg" "$onedark_white"


### PR DESCRIPTION
Stop setting the background color of the tmux window. The effect of this change is to make tmux transparent in transparent terminals. One a properly set up terminal, this would have no other effect, as the background color of the terminal would be set correctly anyway.

This is a true fix for https://github.com/odedlaz/tmux-onedark-theme/issues/5.

As examples: the window background color is not set in the following two tmux themes, both of which have good out-of-the-box transparent terminal support:

https://github.com/shaneog/tmux-colors-gotham
https://github.com/sei40kr/tmux-airline-dracula

I can change this to be toggled with an option, if you'd prefer that.