### PR TITLE
Use black for session name

### DIFF
--- a/tmux-onedark-theme.tmux
+++ b/tmux-onedark-theme.tmux
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 onedark_black="#282c34"
 onedark_blue="#61afef"
 onedark_yellow="#e5c07b"
@@ -72,17 +73,15 @@ set "display-panes-colour" "$onedark_blue"
 set "status-bg" "$onedark_black"
 set "status-fg" "$onedark_white"
 
-set "@prefix_highlight_fg" "$onedark_black"
-set "@prefix_highlight_bg" "$onedark_green"
-set "@prefix_highlight_copy_mode_attr" "fg=$onedark_black,bg=$onedark_green"
-set "@prefix_highlight_output_prefix" "  "
+set "@prefix_highlight_fg" "$onedark_blue"
+set "@prefix_highlight_bg" "$onedark_black"
 
 status_widgets=$(get "@onedark_widgets")
 time_format=$(get "@onedark_time_format" "%R")
 date_format=$(get "@onedark_date_format" "%d/%m/%Y")
 
-set "status-right" "#[fg=$onedark_white,bg=$onedark_black,nounderscore,noitalics]${time_format}  ${date_format} #[fg=$onedark_visual_grey,bg=$onedark_black]#[fg=$onedark_visual_grey,bg=$onedark_visual_grey]#[fg=$onedark_white, bg=$onedark_visual_grey]${status_widgets} #[fg=$onedark_green,bg=$onedark_visual_grey,nobold,nounderscore,noitalics]#[fg=$onedark_black,bg=$onedark_green,bold] #h #[fg=$onedark_yellow, bg=$onedark_green]#[fg=$onedark_red,bg=$onedark_yellow]"
-set "status-left" "#[fg=$onedark_black,bg=$onedark_green,bold] #S #{prefix_highlight}#[fg=$onedark_green,bg=$onedark_black,nobold,nounderscore,noitalics]"
+set "status-left" "#[fg=$onedark_black,bg=$onedark_blue] #S "
+set "status-right" "#{prefix_highlight}#[fg=$onedark_white,bg=$onedark_black]${time_format} | ${date_format} #[fg=$onedark_white, bg=$onedark_visual_grey] ${status_widgets} #[fg=$onedark_black,bg=$onedark_blue] #h "
 
-set "window-status-format" "#[fg=$onedark_black,bg=$onedark_black,nobold,nounderscore,noitalics]#[fg=$onedark_white,bg=$onedark_black] #I  #W #[fg=$onedark_black,bg=$onedark_black,nobold,nounderscore,noitalics]"
-set "window-status-current-format" "#[fg=$onedark_black,bg=$onedark_visual_grey,nobold,nounderscore,noitalics]#[fg=$onedark_white,bg=$onedark_visual_grey,nobold] #I  #W #[fg=$onedark_visual_grey,bg=$onedark_black,nobold,nounderscore,noitalics]"
+set "window-status-format" " #[fg=$onedark_white,bg=$onedark_black] #I #W "
+set "window-status-current-format" " #[fg=$onedark_white,bg=$onedark_visual_grey] #I #W #[fg=$onedark_black]"

--- a/tmux-onedark-theme.tmux
+++ b/tmux-onedark-theme.tmux
@@ -61,9 +61,9 @@ setw "window-status-separator" ""
 set "window-style" "fg=$onedark_white"
 set "window-active-style" "fg=$onedark_white"
 
-set "pane-border-fg" "$onedark_white"
+set "pane-border-fg" "$onedark_comment_grey"
 set "pane-border-bg" "$onedark_black"
-set "pane-active-border-fg" "$onedark_green"
+set "pane-active-border-fg" "$onedark_white"
 set "pane-active-border-bg" "$onedark_black"
 
 set "display-panes-active-colour" "$onedark_yellow"

--- a/tmux-onedark-theme.tmux
+++ b/tmux-onedark-theme.tmux
@@ -82,7 +82,7 @@ time_format=$(get "@onedark_time_format" "%R")
 date_format=$(get "@onedark_date_format" "%d/%m/%Y")
 
 set "status-right" "#[fg=$onedark_white,bg=$onedark_black,nounderscore,noitalics]${time_format}  ${date_format} #[fg=$onedark_visual_grey,bg=$onedark_black]#[fg=$onedark_visual_grey,bg=$onedark_visual_grey]#[fg=$onedark_white, bg=$onedark_visual_grey]${status_widgets} #[fg=$onedark_green,bg=$onedark_visual_grey,nobold,nounderscore,noitalics]#[fg=$onedark_black,bg=$onedark_green,bold] #h #[fg=$onedark_yellow, bg=$onedark_green]#[fg=$onedark_red,bg=$onedark_yellow]"
-set "status-left" "#[fg=$onedark_visual_grey,bg=$onedark_green,bold] #S #{prefix_highlight}#[fg=$onedark_green,bg=$onedark_black,nobold,nounderscore,noitalics]"
+set "status-left" "#[fg=$onedark_black,bg=$onedark_green,bold] #S #{prefix_highlight}#[fg=$onedark_green,bg=$onedark_black,nobold,nounderscore,noitalics]"
 
 set "window-status-format" "#[fg=$onedark_black,bg=$onedark_black,nobold,nounderscore,noitalics]#[fg=$onedark_white,bg=$onedark_black] #I  #W #[fg=$onedark_black,bg=$onedark_black,nobold,nounderscore,noitalics]"
 set "window-status-current-format" "#[fg=$onedark_black,bg=$onedark_visual_grey,nobold,nounderscore,noitalics]#[fg=$onedark_white,bg=$onedark_visual_grey,nobold] #I  #W #[fg=$onedark_visual_grey,bg=$onedark_black,nobold,nounderscore,noitalics]"

--- a/tmux-onedark-theme.tmux
+++ b/tmux-onedark-theme.tmux
@@ -58,7 +58,7 @@ setw "window-status-activity-attr" "none"
 
 setw "window-status-separator" ""
 
-set "window-style" "fg=$onedark_comment_grey"
+set "window-style" "fg=$onedark_white"
 set "window-active-style" "fg=$onedark_white"
 
 set "pane-border-fg" "$onedark_white"

--- a/tmux-onedark-theme.tmux
+++ b/tmux-onedark-theme.tmux
@@ -73,15 +73,15 @@ set "display-panes-colour" "$onedark_blue"
 set "status-bg" "$onedark_black"
 set "status-fg" "$onedark_white"
 
-set "@prefix_highlight_fg" "$onedark_blue"
-set "@prefix_highlight_bg" "$onedark_black"
+set "@prefix_highlight_fg" "$onedark_black"
+set "@prefix_highlight_bg" "$onedark_blue"
 
 status_widgets=$(get "@onedark_widgets")
 time_format=$(get "@onedark_time_format" "%R")
 date_format=$(get "@onedark_date_format" "%d/%m/%Y")
 
 set "status-left" "#[fg=$onedark_black,bg=$onedark_blue] #S "
-set "status-right" "#{prefix_highlight}#[fg=$onedark_white,bg=$onedark_black]${time_format} | ${date_format} #[fg=$onedark_white, bg=$onedark_visual_grey] ${status_widgets} #[fg=$onedark_black,bg=$onedark_blue] #h "
+set "status-right" "#{prefix_highlight} #[fg=$onedark_white,bg=$onedark_black]${time_format} | ${date_format} #[fg=$onedark_white, bg=$onedark_visual_grey] ${status_widgets} #[fg=$onedark_black,bg=$onedark_blue] #h "
 
 set "window-status-format" " #[fg=$onedark_white,bg=$onedark_black] #I #W "
 set "window-status-current-format" " #[fg=$onedark_white,bg=$onedark_visual_grey] #I #W #[fg=$onedark_black]"


### PR DESCRIPTION
The foreground color should be consistent with the hostname, which uses
black instead of visual grey.