### PR TITLE
Update shebang to point to /usr/

### DIFF
--- a/tmux-onedark-theme.tmux
+++ b/tmux-onedark-theme.tmux
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 onedark_black="#282c34"
 onedark_blue="#61afef"
 onedark_yellow="#e5c07b"


### PR DESCRIPTION
Bash is not in /bin on nixos so tpm was returning a 127 error. I updated the shebang to #!/usr/env/bin bash to be more compatible.